### PR TITLE
Add a driverurl command to provide access to the pure webdriver url command

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ function WebdriverjsAngular(options) {
 
   var client = this;
   var originalUrl = client.url.bind(client);
+  client.addCommand('driverurl', originalUrl);
 
   patch('init', addTimeout);
   client.addCommand('url', function(url, cb) {


### PR DESCRIPTION
There are a few occasions where I need to use the pure webdriverio url command. For example, our SSO page lacks angularjs although the apps that use it are based on angular. 
